### PR TITLE
Experiment: Inline critical CSS

### DIFF
--- a/postprocessing/process.js
+++ b/postprocessing/process.js
@@ -41,6 +41,15 @@ function main() {
     .source(INPUT_DIR) // source directory
     .destination(OUTPUT_DIR) // destination directory
     .clean(false) // clean destination before
+    .use(
+      criticalCss({
+        pattern: '**/*.html',
+        // The CSS file whose selectors will be matched against the html
+        cssFile: path.join(INPUT_DIR, hashedCssFilename),
+        // The path under which the css is included in the template
+        cssPublicPath: hashedCssFilename,
+      })
+    )
     .build(function(err) {
       if (err) {
         console.log('Error running the postprocessing pipeline: ' + err);


### PR DESCRIPTION
When the browser encounters a `<link rel="stylesheet">` in the `<head>`, it pauses, goes to the network, fetches the file, and only then continues. This is called "render blocking". If it sounds bad for performance, it's because it is! This is especially true for slower networks where the latency alone can add seconds to the request.

To combat this, you can "inline" the used or critical CSS for a page as a `<style>` tag. You then load the rest asynchronously. To do that, you link the stylesheet as `<link rel="preload">`, which decouples downloading from execution, and allows the browser to continue. Once the stylesheet has loaded, it is "swapped in". To account for browsers that do not support rel="preload", we use the excellent LoadCSS relpreload.js.

Inlining the critical CSS for a page is one of the most important optimisations you can do to make your site paint faster!

## See the implementation
https://github.com/fpapado/metalsmith-inline-critical-css

## Read more

- [Filament Group's LoadCSS](https://github.com/filamentgroup/loadCSS)
- [Performance of Wired.com](https://www.filamentgroup.com/lab/weight-wait.html)