### PR TITLE
 Experiment: Use Variable fonts for a minimal font loading strategy #16 

### DIFF
--- a/postprocessing/process.js
+++ b/postprocessing/process.js
@@ -41,6 +41,15 @@ function main() {
     .source(INPUT_DIR) // source directory
     .destination(OUTPUT_DIR) // destination directory
     .clean(false) // clean destination before
+    .use(
+      criticalCss({
+        pattern: '**/*.html',
+        // The CSS file whose selectors will be matched against the html
+        cssFile: path.join(INPUT_DIR, hashedCssFilename),
+        // The path under which the css is included in the template
+        cssPublicPath: hashedCssFilename,
+      })
+    )
     .build(function(err) {
       if (err) {
         console.log('Error running the postprocessing pipeline: ' + err);

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -13,6 +13,11 @@
     <meta name="description" content="{{ renderData.description or description or metadata.description }}">
     <meta name="theme-color" content="#212121">
 
+    {# Preload variable font. Browsers with preload also support variable fonts, so this is a good balance.
+      Fonts are loaded with crossorigin anonymous because of browser behaviour.
+    #}
+    <link rel="preload" href="{{ '/fonts/phantom-sans-v4-variable.woff2' | url}}" as="font" type="font/woff2" crossorigin>
+
     <link rel="stylesheet" href="{{ '/css/index.css' | resolveHash | url }}">
 
     {# Adds an event listener to capture uncaught errors. #}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -24,6 +24,7 @@
 /* Nav */
 .nav-item-active {
   font-weight: 700;
+  font-variation-settings: 'wght' 700;
   text-decoration: underline;
 }
 
@@ -175,10 +176,60 @@ a[href].tag:visited {
 }
 
 /* Font stuff */
+/* Progressively enhance fwX classes to be variable.
+ * NOTE: Phantom Sans v4 goes from Regular - Bold,
+ * so the scale 0 - 1000 is skewed along that range.
+*/
+@supports (font-variation-settings: normal) {
+  .normal {
+    font-variation-settings: 'wght' 1;
+  }
+  .b {
+    font-variation-settings: 'wght' 700;
+  }
+  .fw1 {
+    font-variation-settings: 'wght' 1;
+  }
+  .fw2 {
+    font-variation-settings: 'wght' 1;
+  }
+  .fw3 {
+    font-variation-settings: 'wght' 1;
+  }
+  .fw4 {
+    font-variation-settings: 'wght' 1;
+  }
+  .fw5 {
+    font-variation-settings: 'wght' 400;
+  }
+  .fw6 {
+    font-variation-settings: 'wght' 700;
+  }
+  .fw7 {
+    font-variation-settings: 'wght' 999;
+  }
+  .fw8 {
+    font-variation-settings: 'wght' 999;
+  }
+  .fw9 {
+    font-variation-settings: 'wght' 999;
+  }
+}
+
 /* PhantomSans */
 /* Variable and fallbacks.
  * @see https://medium.com/clear-left-thinking/how-to-use-variable-fonts-in-the-real-world-e6d73065a604
 */
+
+/* PhantomSansVariable
+ * Variable needs only woff2, since their support overlaps.
+*/
+@font-face {
+  font-family: 'PhantomSansVariable';
+  font-display: swap;
+  src: url(/fonts/phantom-sans-v4-variable.woff2) format('woff2');
+  font-weight: 1 999;
+}
 
 /* PhantomSans-regular */
 @font-face {
@@ -203,6 +254,14 @@ a[href].tag:visited {
 .f-phantomsans {
   font-family: 'PhantomSans', Arial, Helvetica, sans-serif;
   font-weight: 400;
+}
+
+@supports (font-variation-settings: normal) {
+  .f-phantomsans {
+    font-family: 'PhantomSansVariable', Arial, Helvetica, sans-serif;
+    /* Normalise font-weight if not specified */
+    font-variation-settings: 'wght' 1;
+  }
 }
 
 /* Skip Link */


### PR DESCRIPTION
Font loading is another thing that the browser will kinda block on.
By default, it will display invisible text for up to 3 seconds, and then fall back to the next font in the stack. This is the Flash of Invisible Text(FOIT). When the font comes in (if ever), then it will swap it in.

This is undesirable for a few reasons:
- The content is there, but the user does not see it!
- Different font weights might come in at different times, which can cause misleading content (e.g. "Mitt Romney is __ running for president"
- If fonts come and go as they please, then the page might re-layout a bunch of times! This is slow, janky, and distracting

For that, we need a **font loading strategy**

## Our strategy
`<link rel="preload">` the font (don't forget to make it `crossorigin`!), to prioritise it without the browser needing to find it in use

Use a single font file, that has all the weights. This is called a Variable font.
The important property is that it should be small (ours is at 26kB, about the size of one weight!).
If it is not, you need a more complex strategy (see below).

Set `font-display: swap` to disable the default blocking behaviour, described above.

Set up fallbacks as appropriate.

Now the browser immediately seeks out the font, as soon as it has html. It also immeidately shows fallbacks. Once the single file comes in, all weights update at once, causing at most one re-layout :tada:

## References
Zach Leatherman's "The Five Whys of Web Font Loading Performance" covers the modern approaches:
https://noti.st/zachleat/KNaZEg/the-five-whys-of-web-font-loading-performance

Zach has tons on font loading on his blog:
https://www.zachleat.com/

Monica Dinculescu has a great demo of `font-display` values:
https://font-display.glitch.me/